### PR TITLE
15 get api articles sort by

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -389,6 +389,65 @@ describe("/api", () => {
 					});
 			});
 		});
+		describe("GET articles in the specified sort order", () => {
+			test("GET: 200 articles?order=asc should return all the articles in ascending order", () => {
+				return request(app)
+					.get("/api/articles?order=asc")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("created_at", {
+							ascending: true,
+						});
+					});
+			});
+			test("GET: 200 articles?order=ASC should return all the articles in ascending order", () => {
+				return request(app)
+					.get("/api/articles?order=ASC")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("created_at", {
+							ascending: true,
+						});
+					});
+			});
+			test("GET: 400 articles?order=invalid should return Bad Request", () => {
+				return request(app)
+					.get("/api/articles?order=invalid")
+					.expect(400)
+					.then((response) => {
+						const { msg } = response.body;
+						expect(msg).toBe("Bad Request");
+					});
+			});
+			test("GET: 200 articles?order=desc should return all the articles in descending order", () => {
+				return request(app)
+					.get("/api/articles?order=desc")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("created_at", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 200 articles?topic=mitch&sort_by=votes&order=asc should respond with specified article, correctly sorted", () => {
+				return request(app)
+					.get("/api/articles?topic=mitch&sort_by=votes&order=asc")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles.length).toBe(12);
+						expect(articles).toBeSortedBy("votes", {
+							ascending: true,
+						});
+						articles.forEach((article) => {
+							expect(article.topic).toBe("mitch");
+						});
+					});
+			});
+		});
 	});
 	describe("POST /articles comment by article_id", () => {
 		test("POST: 201 /1/comments should add the comment and respond with the new comment", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -4,6 +4,7 @@ const db = require("../db/connection");
 const data = require("../db/data/test-data");
 const seed = require("../db/seeds/seed");
 const { expect } = require("@jest/globals");
+const { forEach } = require("../db/data/test-data/articles");
 
 beforeEach(() => {
 	consoleSpy = jest.spyOn(console, "log");
@@ -114,7 +115,7 @@ describe("/api", () => {
 					});
 			});
 		});
-		describe("GET articles", () => {
+		describe.only("GET articles", () => {
 			test("GET: 200 / should respond with an array of article objects with the defined properties, _not including_ comment_count", () => {
 				return request(app)
 					.get("/api/articles/")
@@ -304,6 +305,87 @@ describe("/api", () => {
 					.then((response) => {
 						const { comments } = response.body;
 						expect(comments.length).toBe(0);
+					});
+			});
+		});
+		describe.only("GET articles sorted by the following queries: title, topic, author, date, votes", () => {
+			test("GET: 200 ?sort_by=title should serve the articles sorted by title, default descending", () => {
+				return request(app)
+					.get("/api/articles?sort_by=title")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("title", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 400 ?sort_by=invalid should return Bad Request", () => {
+				return request(app)
+					.get("/api/articles?sort_by=invalid")
+					.expect(400)
+					.then((response) => {
+						const { msg } = response.body;
+						expect(msg).toBe("Bad Request");
+					});
+			});
+			test("GET: 200 ?sort_by=topic should serve the articles sorted by topic, default descending", () => {
+				return request(app)
+					.get("/api/articles?sort_by=topic")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("topic", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 200 ?sort_by=author should serve the articles sorted by author, default descending", () => {
+				return request(app)
+					.get("/api/articles?sort_by=author")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("author", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 200 ?sort_by=created_at should serve the articles sorted by created_at, default descending", () => {
+				return request(app)
+					.get("/api/articles?sort_by=created_at")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("created_at", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 200 ?sort_by=votes should serve the articles sorted by votes, default descending", () => {
+				return request(app)
+					.get("/api/articles?sort_by=votes")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles).toBeSortedBy("votes", {
+							descending: true,
+						});
+					});
+			});
+			test("GET: 200 ?topic=mitch&sort_by=votes should serve the articles with topic of mitch, sorted by votes, default descending", () => {
+				return request(app)
+					.get("/api/articles?topic=mitch&sort_by=votes")
+					.expect(200)
+					.then((response) => {
+						const { articles } = response.body;
+						expect(articles.length).toBe(12);
+						expect(articles).toBeSortedBy("votes", {
+							descending: true,
+						});
+						articles.forEach((article) => {
+							expect(article.topic).toBe("mitch");
+						});
 					});
 			});
 		});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -115,7 +115,7 @@ describe("/api", () => {
 					});
 			});
 		});
-		describe.only("GET articles", () => {
+		describe("GET articles", () => {
 			test("GET: 200 / should respond with an array of article objects with the defined properties, _not including_ comment_count", () => {
 				return request(app)
 					.get("/api/articles/")
@@ -308,7 +308,7 @@ describe("/api", () => {
 					});
 			});
 		});
-		describe.only("GET articles sorted by the following queries: title, topic, author, date, votes", () => {
+		describe("GET articles sorted by the following queries: title, topic, author, date, votes", () => {
 			test("GET: 200 ?sort_by=title should serve the articles sorted by title, default descending", () => {
 				return request(app)
 					.get("/api/articles?sort_by=title")

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -17,8 +17,8 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-	const { topic } = req.query;
-	const articlesQuery = fetchArticles(topic);
+	const { topic, sort_by } = req.query;
+	const articlesQuery = fetchArticles(topic, sort_by);
 	const queries = [articlesQuery];
 	if (topic) {
 		const topicExistsQuery = checkTopicExists(topic);

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -17,8 +17,8 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-	const { topic, sort_by } = req.query;
-	const articlesQuery = fetchArticles(topic, sort_by);
+	const { topic, sort_by, order } = req.query;
+	const articlesQuery = fetchArticles(topic, sort_by, order);
 	const queries = [articlesQuery];
 	if (topic) {
 		const topicExistsQuery = checkTopicExists(topic);

--- a/endpoints.json
+++ b/endpoints.json
@@ -13,7 +13,8 @@
 		"description": "serves an array of all articles, default sorted by descending created_at",
 		"queries": [
 			"topic",
-			{ "sort_by": ["title", "topic", "author", "created_at", "votes"] }
+			{ "sort_by": ["title", "topic", "author", "created_at", "votes"] },
+			{ "order": ["asc", "ASC", "DESC", "desc"] }
 		],
 		"exampleResponse": {
 			"articles": [

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,10 @@
 	},
 	"GET /api/articles": {
 		"description": "serves an array of all articles, default sorted by descending created_at",
-		"queries": ["topic"],
+		"queries": [
+			"topic",
+			{ "sort_by": ["title", "topic", "author", "created_at", "votes"] }
+		],
 		"exampleResponse": {
 			"articles": [
 				{

--- a/errors.js
+++ b/errors.js
@@ -6,6 +6,8 @@ exports.handleCustomErrors = (err, req, res, next) => {
 		err.msg === "no such comment"
 	) {
 		res.status(404).send({ msg: "Not Found" });
+	} else if (err.msg === "invalid sort query") {
+		res.status(400).send({ msg: "Bad Request" });
 	} else {
 		next(err);
 	}

--- a/errors.js
+++ b/errors.js
@@ -6,7 +6,10 @@ exports.handleCustomErrors = (err, req, res, next) => {
 		err.msg === "no such comment"
 	) {
 		res.status(404).send({ msg: "Not Found" });
-	} else if (err.msg === "invalid sort query") {
+	} else if (
+		err.msg === "invalid sort query" ||
+		err.msg === "invalid order query"
+	) {
 		res.status(400).send({ msg: "Bad Request" });
 	} else {
 		next(err);

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -21,12 +21,15 @@ exports.fetchArticleById = (article_id) => {
 		});
 };
 
-exports.fetchArticles = (topic, sort_by = "created_at") => {
+exports.fetchArticles = (topic, sort_by = "created_at", order = "DESC") => {
 	const queryValues = [];
 	const validSortQuery = ["created_at", "title", "topic", "author", "votes"];
-
+	const validOrderQuery = ["DESC", "desc", "ASC", "asc"];
 	if (!validSortQuery.includes(sort_by)) {
 		return Promise.reject({ msg: "invalid sort query" });
+	}
+	if (!validOrderQuery.includes(order)) {
+		return Promise.reject({ msg: "invalid order query" });
 	}
 
 	let queryStr = `SELECT articles.*, COUNT(comments.comment_id) 
@@ -36,7 +39,8 @@ exports.fetchArticles = (topic, sort_by = "created_at") => {
 		queryValues.push(topic);
 		queryStr += ` WHERE topic = $1`;
 	}
-	queryStr += ` GROUP BY articles.article_id ORDER BY ${sort_by} DESC`;
+	queryStr += ` GROUP BY articles.article_id `;
+	queryStr += ` ORDER BY ${sort_by} ${order}`;
 
 	return db.query(queryStr, queryValues).then((results) => {
 		return results.rows;

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -21,8 +21,14 @@ exports.fetchArticleById = (article_id) => {
 		});
 };
 
-exports.fetchArticles = (topic) => {
+exports.fetchArticles = (topic, sort_by = "created_at") => {
 	const queryValues = [];
+	const validSortQuery = ["created_at", "title", "topic", "author", "votes"];
+
+	if (!validSortQuery.includes(sort_by)) {
+		return Promise.reject({ msg: "invalid sort query" });
+	}
+
 	let queryStr = `SELECT articles.*, COUNT(comments.comment_id) 
 	AS comment_count FROM articles LEFT OUTER JOIN comments 
 	ON comments.article_id = articles.article_id`;
@@ -30,7 +36,8 @@ exports.fetchArticles = (topic) => {
 		queryValues.push(topic);
 		queryStr += ` WHERE topic = $1`;
 	}
-	queryStr += ` GROUP BY articles.article_id ORDER BY created_at DESC`;
+	queryStr += ` GROUP BY articles.article_id ORDER BY ${sort_by} DESC`;
+
 	return db.query(queryStr, queryValues).then((results) => {
 		return results.rows;
 	});


### PR DESCRIPTION
This completes ticket 15 to add `sort_by` and `order` queries to the /api/articles endpoint.